### PR TITLE
Enable gifski

### DIFF
--- a/com.uploadedlobster.peek.json
+++ b/com.uploadedlobster.peek.json
@@ -3,6 +3,7 @@
   "runtime": "org.gnome.Platform",
   "runtime-version": "3.26",
   "sdk": "org.gnome.Sdk",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
   "command": "peek",
   "finish-args": [
     "--share=ipc",
@@ -21,8 +22,10 @@
     "cflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
     "cxxflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
     "ldflags": "-fstack-protector-strong -Wl,-z,relro,-z,now",
+    "append-path": "/usr/lib/sdk/rust-stable/bin",
     "env": {
-      "V": "1"
+      "V": "1",
+      "CARGO_HOME": "/run/build/gifski/cargo"
     }
   },
   "cleanup": [
@@ -102,6 +105,21 @@
             "/bin/x264"
           ]
         }
+      ]
+    },
+    {
+      "name": "gifski",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/ImageOptim/gifski/archive/0.6.2.tar.gz",
+          "sha256": "4f0379aa05a5e99fd6a9efb851efa7553e9663ec800ac7247fb7e26505a4b225"
+        }
+      ],
+      "build-commands": [
+        "cargo build --release",
+        "install -Dm755 target/release/gifski /app/bin/gifski"
       ]
     },
     {

--- a/com.uploadedlobster.peek.json
+++ b/com.uploadedlobster.peek.json
@@ -115,6 +115,10 @@
           "type": "archive",
           "url": "https://github.com/ImageOptim/gifski/archive/0.6.2.tar.gz",
           "sha256": "4f0379aa05a5e99fd6a9efb851efa7553e9663ec800ac7247fb7e26505a4b225"
+        },
+        {
+          "type": "archive",
+          "path": "gifski-vendor.tar.xz"
         }
       ],
       "build-commands": [


### PR DESCRIPTION
Sigh, for some reason I couldn't re-open the old one, so there we go again.

How to recreate `gifski-vendor.tar.xz`: use cargo-vendor to create `vendor` directory. Next, create `.cargo/config` with the content cargo-vendor printed on the exit; change the last line to `vendor` to make path to `source.vendored-sources` relative.

Of course the best scenario is upstream doing this themselves for release tarball or at least by you @phw as part of peek release. I added it to git directly to prove that it works.