### PR TITLE
Fix ffmpeg using wrong shared libraries

### DIFF
--- a/com.uploadedlobster.peek.json
+++ b/com.uploadedlobster.peek.json
@@ -97,7 +97,6 @@
             {
               "type": "git",
               "url": "https://git.videolan.org/git/x264.git",
-              "branch": "stable",
               "commit": "aaa9aa83a111ed6f1db253d5afa91c5fc844583f"
             }
           ],

--- a/com.uploadedlobster.peek.json
+++ b/com.uploadedlobster.peek.json
@@ -16,7 +16,8 @@
     "--filesystem=xdg-run/dconf",
     "--filesystem=~/.config/dconf:ro",
     "--talk-name=ca.desrt.dconf",
-    "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+    "--env=LD_LIBRARY_PATH=/app/lib"
   ],
   "build-options" : {
     "cflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
@@ -82,8 +83,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://ffmpeg.org/releases/ffmpeg-3.4.tar.xz",
-          "sha256": "aeee06e4d8b18d852c61ebbfe5e1bb7014b1e118e8728c1c2115f91e51bffbef"
+          "url": "https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.xz",
+          "sha256": "5a77278a63741efa74e26bf197b9bb09ac6381b9757391b922407210f0f991c0"
         }
       ],
       "modules": [


### PR DESCRIPTION
Set LD_LIBRARY_PATH to ensure ffmpeg uses our custom build libraries